### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,9 @@ on:
   push:
     tags:
       - 'v*.*.*'
+permissions:
+  contents: read
+  packages: write
 jobs:
   push_to_registry:
     name: Push Docker image to GitHub Packages


### PR DESCRIPTION
Potential fix for [https://github.com/pataar/efteling-node-exporter/security/code-scanning/2](https://github.com/pataar/efteling-node-exporter/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/main.yml` to enforce least privilege for `GITHUB_TOKEN`.

Best fix without changing functionality:
- Add workflow-level permissions (applies to all jobs unless overridden) directly under `on:` (or before `jobs:`).
- Set:
  - `contents: read` (needed for repository read operations like checkout)
  - `packages: write` (required to push container images to GitHub Container Registry)

This keeps existing behavior (build + push image) while preventing overly broad default token access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
