### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,6 +6,8 @@ on:
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: write
 jobs:
   update_changelog:
     name: Update the changelog based on the latest commits


### PR DESCRIPTION
Potential fix for [https://github.com/pataar/efteling-node-exporter/security/code-scanning/1](https://github.com/pataar/efteling-node-exporter/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/changelog.yml` so the workflow does not inherit potentially broad defaults.  
Best single fix without changing functionality: define workflow-level permissions with only what this workflow needs:

- `contents: write` (required to commit/push `CHANGELOG.md`)
- no extra scopes

Place this near the top level (after `concurrency` or before `jobs`) so it applies to all jobs in this workflow (currently one job). No imports/dependencies/methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
